### PR TITLE
Upgrade setuptools in Dockerfile

### DIFF
--- a/docker/platform/airflow/Dockerfile
+++ b/docker/platform/airflow/Dockerfile
@@ -49,6 +49,7 @@ RUN apk add --no-cache --virtual .build-deps \
 		postgresql \
 		python3 \
 		tini \
+	&& pip3 install --no-cache-dir --upgrade setuptools \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 uninstall -y snakebite \
 	&& apk del .build-deps \


### PR DESCRIPTION
This PR applies fix  which upgrades pip3 setuptools in order to resolve an install issue with googleapis-common-protos lib