### PR TITLE
Hotfix/update maintainer label

### DIFF
--- a/docker/platform/airflow/Dockerfile
+++ b/docker/platform/airflow/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM astronomerinc/ap-base
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/platform/airflow/onbuild/Dockerfile
+++ b/docker/platform/airflow/onbuild/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM astronomerinc/ap-airflow
-MAINTAINER  Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true

--- a/docker/platform/base/Dockerfile
+++ b/docker/platform/base/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM alpine:3.7
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 ARG ASTRONOMER_USER=astro

--- a/docker/platform/commander/Dockerfile
+++ b/docker/platform/commander/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM astronomerinc/ap-base
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/platform/default-backend/Dockerfile
+++ b/docker/platform/default-backend/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM astronomerinc/ap-base
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/platform/event-api/Dockerfile
+++ b/docker/platform/event-api/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
 	&& make DESTDIR=/tmp install
 
 FROM astronomerinc/ap-base
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/platform/event-forwarder/Dockerfile
+++ b/docker/platform/event-forwarder/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM astronomerinc/ap-base
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/platform/event-router/Dockerfile
+++ b/docker/platform/event-router/Dockerfile
@@ -40,7 +40,7 @@ RUN apk add --no-cache \
 	&& make DESTDIR=/tmp install
 
 FROM astronomerinc/ap-base
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/platform/houston-api/Dockerfile
+++ b/docker/platform/houston-api/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 FROM astronomerinc/ap-base
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/vendor/cadvisor/Dockerfile
+++ b/docker/vendor/cadvisor/Dockerfile
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 FROM google/cadvisor:v0.28.3
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
-
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/vendor/grafana/Dockerfile
+++ b/docker/vendor/grafana/Dockerfile
@@ -14,10 +14,9 @@
 # limitations under the License.
 
 FROM grafana/grafana:master
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
-
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 

--- a/docker/vendor/nginx/Dockerfile
+++ b/docker/vendor/nginx/Dockerfile
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 FROM gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
-
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/vendor/prometheus/Dockerfile
+++ b/docker/vendor/prometheus/Dockerfile
@@ -14,10 +14,9 @@
 # limitations under the License.
 
 FROM prom/prometheus:v2.0.0
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
-
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 

--- a/docker/vendor/registry/Dockerfile
+++ b/docker/vendor/registry/Dockerfile
@@ -14,9 +14,8 @@
 # limitations under the License.
 
 FROM registry:2.6.2
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
-
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER

--- a/docker/vendor/statsd-exporter/Dockerfile
+++ b/docker/vendor/statsd-exporter/Dockerfile
@@ -14,10 +14,9 @@
 # limitations under the License.
 
 FROM prom/statsd-exporter:v0.5.0
-MAINTAINER Astronomer <humans@astronomer.io>
+LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1
-
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 


### PR DESCRIPTION
Updates repo to remove deprecated MAINTAINER attr in favor of LABEL maintainer="" attr 

https://docs.docker.com/engine/reference/builder/#maintainer-deprecated