### PR TITLE
Pin setuptools for deterministic build

### DIFF
--- a/docker/platform/airflow/Dockerfile
+++ b/docker/platform/airflow/Dockerfile
@@ -49,7 +49,7 @@ RUN apk add --no-cache --virtual .build-deps \
 		postgresql \
 		python3 \
 		tini \
-	&& pip3 install --no-cache-dir --upgrade setuptools \
+	&& pip3 install --no-cache-dir --upgrade setuptools==39.0.1 \
 	&& pip3 install --no-cache-dir "${AIRFLOW_MODULE}" \
 	&& pip3 uninstall -y snakebite \
 	&& apk del .build-deps \


### PR DESCRIPTION
Recently we merged upgrading to the latest `setuptools` to support another dependency.  This builds on that to PR #46 to pin `setuptools` like we do other Python packages so we can ensure that our builds are deterministic when future releases of `setuptools` are published.