### PR TITLE
Upgrade nginx to 0.12.0

### DIFF
--- a/docker/vendor/nginx/Dockerfile
+++ b/docker/vendor/nginx/Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.15
+FROM quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.12.0
 LABEL maintainer="Astronomer <humans@astronomer.io>"
 
 ARG BUILD_NUMBER=-1


### PR DESCRIPTION
Note: Untested

The kubernetes/ingress-nginx repo is now publishing to quay.io as the new image registry [over gcr.io](https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.12.0).

Changelog: https://github.com/kubernetes/ingress-nginx/blob/cd4ddb72ac1f43da6a781b6c8ce4537751339445/Changelog.md#0120

Diff: https://github.com/kubernetes/ingress-nginx/compare/nginx-0.9.0-beta.15...nginx-0.12.0
