### PR TITLE
Change link to HTTPS to fix live

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -19,7 +19,7 @@
   <link rel="stylesheet" href="{{ "/assets/css/styles.css" | relative_url }}">
 
   <script
-    src="http://code.jquery.com/jquery-3.3.1.min.js"
+    src="https://code.jquery.com/jquery-3.3.1.min.js"
     integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
     crossorigin="anonymous"></script>
   <script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>


### PR DESCRIPTION
https://open.astronomer.io currently doesn't load jQuery because the jQuery link isn't `https://...`