### PR TITLE
Adding start/stop/pause scripts back. Updated docs

### DIFF
--- a/examples/airflow-core/pause
+++ b/examples/airflow-core/pause
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker-compose stop

--- a/examples/airflow-core/start
+++ b/examples/airflow-core/start
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+if [ ! -z $1 ] && [ -d $1 ]; then
+	BASE_IMAGE_NAME="astronomerinc/ap-airflow"
+	REQUIREMENTS="$1/requirements.txt"
+	PACKAGES="$1/packages.txt"
+	DOCKERFILE="$1/Dockerfile"
+	export AIRFLOW_HOME=$1
+	echo ${DOCKERFILE}
+
+	# Create default dockerfile using onbuild image as base
+	if [ ! -f $DOCKERFILE ]; then
+		echo "FROM ${BASE_IMAGE_NAME}:latest-onbuild" >> $DOCKERFILE
+	fi
+
+	# Create default requirements.txt
+	if [ ! -f $REQUIREMENTS ]; then
+		echo "noop==1.0.0" >> $REQUIREMENTS
+	fi
+	echo ${REQUIREMENTS}
+
+	# Create default packages.txt
+	if [ ! -f $PACKAGES ]; then
+		touch $PACKAGES
+	fi
+
+	# Build astronomerio/airflow:DIR_NAME image
+	DIR_NAME=`echo ${1%/} | rev | awk -F \/ '{print $1}' | rev`
+	docker build -t "${BASE_IMAGE_NAME}:${DIR_NAME}" -f ${DOCKERFILE} $1 || exit 1
+
+	# If we have an enhanced image built, specify tag here and use it
+	if [ -f $REQUIREMENTS ] || [ -f $PACKAGES ]; then
+		export AIRFLOW_IMAGE_TAG=${DIR_NAME}
+	else
+		echo "$1 has no packages or requirements, skipping build."
+	fi
+
+else
+    echo "No valid directory specified, starting an empty Airflow..."
+fi
+
+# Run Docker Compose
+docker-compose up
+
+printf "\nAirflow Core Started\n"
+printf "\nAirflow Webserver running at http://localhost:8080\n"
+printf "\nExecute ./pause to stop containers and keep all data."
+printf "\nExecute ./kill to stop containers and remove all data.\n\n"

--- a/examples/airflow-core/stop
+++ b/examples/airflow-core/stop
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker-compose down -v

--- a/examples/airflow-enterprise/pause
+++ b/examples/airflow-enterprise/pause
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker-compose stop

--- a/examples/airflow-enterprise/start
+++ b/examples/airflow-enterprise/start
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+WORKERS_COUNT=2
+COMPOSEFILE='./docker-compose.yml'
+SCALEWORKER='--scale worker='
+
+if [ ! -z $1 ] && [ -d $1 ]; then
+	BASE_IMAGE_NAME="astronomerinc/ap-airflow"
+	REQUIREMENTS="$1/requirements.txt"
+	PACKAGES="$1/packages.txt"
+	DOCKERFILE="$1/Dockerfile"
+	export AIRFLOW_HOME=$1
+
+	# Create default dockerfile using onbuild image as base
+	if [ ! -f $DOCKERFILE ]; then
+		echo "FROM ${BASE_IMAGE_NAME}:latest-onbuild" >> $DOCKERFILE
+	fi
+
+	# Create default requirements.txt
+	if [ ! -f $REQUIREMENTS ]; then
+		echo "noop==1.0.0" >> $REQUIREMENTS
+	fi
+
+	# Create default packages.txt
+	if [ ! -f $PACKAGES ]; then
+		touch $PACKAGES
+	fi
+
+	# Build astronomerio/airflow:DIR_NAME image
+	DIR_NAME=`echo ${1%/} | rev | awk -F \/ '{print $1}' | rev`
+	docker build -t "${BASE_IMAGE_NAME}:${DIR_NAME}" -f ${DOCKERFILE} $1 || exit 1
+
+	# If we have an enhanced image built, specify tag here and use it
+	if [ -f $REQUIREMENTS ] || [ -f $PACKAGES ]; then
+		export AIRFLOW_IMAGE_TAG=${DIR_NAME}
+	else
+		echo "$1 has no packages or requirements, skipping build."
+	fi
+
+else
+echo "No valid directory specified, starting an empty Airflow..."
+fi
+
+# Run Docker Compose
+docker-compose -f ${COMPOSEFILE} up -d ${SCALEWORKER}${WORKERS_COUNT}
+
+printf "\nAirflow webserver running at http://localhost:8080\n"
+printf "Scheduler dashboard running at http://localhost:3000/dashboard/db/airflow-scheduler\n"
+printf "Container dashboard running at http://localhost:3000/dashboard/db/airflow-containers\n"
+printf "Flower (Celery Monitoring) running at http://localhost:5555\n"
+printf "Prometheus UI running at http://localhost:9090\n"
+printf "cAdvisor UI running at http://localhost:8081\n"
+
+printf "\nExecute ./pause to stop containers and keep all data.\n"
+printf "Execute ./kill to stop containers and remove all data.\n\n"

--- a/examples/airflow-enterprise/stop
+++ b/examples/airflow-enterprise/stop
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker-compose down -v


### PR DESCRIPTION
Readded the start, stop, and pause scripts as they are the best way to run the examples when custom python and/or alpine packages are needed.