### PR TITLE
Add ability to build and push release candidate builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,15 +7,21 @@ REPOSITORY ?= astronomerinc
 # Bump this on subsequent build, reset on new version or public release. Inherit from env for CI builds.
 BUILD_NUMBER ?= 1
 
+# Build version
 ASTRONOMER_MAJOR_VERSION ?= 0
-ASTRONOMER_MINOR_VERSION ?= 2
-ASTRONOMER_PATCH_VERSION ?= 1
+ASTRONOMER_MINOR_VERSION ?= 3
+ASTRONOMER_PATCH_VERSION ?= 0
 ASTRONOMER_VERSION ?= "${ASTRONOMER_MAJOR_VERSION}.${ASTRONOMER_MINOR_VERSION}.${ASTRONOMER_PATCH_VERSION}"
 
-# List of all components and order to build.
+# Platform components
 PLATFORM_COMPONENTS := base default-backend commander houston-api airflow
+PLATFORM_RC_COMPONENTS := default-backend commander houston-api
 PLATFORM_ONBUILD_COMPONENTS := airflow
+
+# Vendor components
 VENDOR_COMPONENTS := nginx registry cadvisor grafana prometheus statsd-exporter
+
+# All components
 ALL_COMPONENTS := ${PLATFORM_COMPONENTS} ${VENDOR_COMPONENTS}
 
 # Documentation build vars.
@@ -30,21 +36,44 @@ DOCS_DEST := docs/_site
 .PHONY: build
 build:
 	PLATFORM_COMPONENTS="${PLATFORM_COMPONENTS}" \
+	PLATFORM_RC_COMPONENTS="${PLATFORM_RC_COMPONENTS}" \
 	VENDOR_COMPONENTS="${VENDOR_COMPONENTS}" \
 	REPOSITORY=${REPOSITORY} \
 	ASTRONOMER_VERSION=${ASTRONOMER_VERSION} \
 	BUILD_NUMBER=${BUILD_NUMBER} \
 	bin/build-images
 
-.PHONY: push-images
-push-images: clean build
+.PHONY: push
+push: clean build push-latest push-versioned
+
+.PHONY: build-rc
+build-rc:
+ifndef ASTRONOMER_RC_VERSION
+	$(error ASTRONOMER_RC_VERSION must be defined)
+endif
+	$(MAKE) ASTRONOMER_VERSION=${ASTRONOMER_VERSION}-rc.${ASTRONOMER_RC_VERSION} build
+
+.PHONY: push-rc
+push-rc: build-rc
+	$(MAKE) ASTRONOMER_VERSION=${ASTRONOMER_VERSION}-rc.${ASTRONOMER_RC_VERSION} push-versioned
+
+.PHONY: push-latest
+push-latest:
 	for component in ${ALL_COMPONENTS} ; do \
-		echo "Pushing ap-$${component} ========================================"; \
+		echo "Pushing ap-$${component}:latest =================================="; \
 		docker push ${REPOSITORY}/ap-$${component}:latest || exit 1; \
-		docker push ${REPOSITORY}/ap-$${component}:${ASTRONOMER_VERSION} || exit 1; \
 	done; \
 	for component in ${PLATFORM_ONBUILD_COMPONENTS} ; do \
 		docker push ${REPOSITORY}/ap-$${component}:latest-onbuild || exit 1; \
+	done
+
+.PHONY: push-versioned
+push-versioned:
+	for component in ${ALL_COMPONENTS} ; do \
+		echo "Pushing ap-$${component}:${ASTRONOMER_VERSION} =================================="; \
+		docker push ${REPOSITORY}/ap-$${component}:${ASTRONOMER_VERSION} || exit 1; \
+	done; \
+	for component in ${PLATFORM_ONBUILD_COMPONENTS} ; do \
 		docker push ${REPOSITORY}/ap-$${component}:${ASTRONOMER_VERSION}-onbuild || exit 1; \
 	done
 

--- a/bin/build-images
+++ b/bin/build-images
@@ -7,10 +7,18 @@ function build_component () {
     DOCKER_DIR="docker/${1}/${2}"
     DOCKER_FILE="${DOCKER_DIR}/Dockerfile"
     COMPONENT_NAME="ap-${2}"
+    BUILD_ARGS="--build-arg BUILD_NUMBER=${BUILD_NUMBER}"
+
+    # If we're building an RC, build platform components from master
+    if [ -v "ASTRONOMER_RC_VERSION" ] && [[ "${PLATFORM_RC_COMPONENTS}" =~ ${2} ]] ; then
+        BUILD_ARGS="${BUILD_ARGS} --build-arg VERSION=master"
+    fi
+
+    echo ${BUILD_ARGS}
 
     # Build normal components
     if [ -f "${DOCKER_FILE}" ]; then
-        docker build --build-arg BUILD_NUMBER="${BUILD_NUMBER}" -t "${REPOSITORY}/${COMPONENT_NAME}:latest" -f "${DOCKER_FILE}" "${DOCKER_DIR}" || exit 1
+        docker build ${BUILD_ARGS} -t "${REPOSITORY}/${COMPONENT_NAME}:latest" -f "${DOCKER_FILE}" "${DOCKER_DIR}" || exit 1
         docker tag "${REPOSITORY}/${COMPONENT_NAME}:latest" "${REPOSITORY}/${COMPONENT_NAME}:${ASTRONOMER_VERSION}"
     fi
 
@@ -19,7 +27,7 @@ function build_component () {
 
     # Build onbuild components
     if [ -f "${ONBUILD_DOCKER_FILE}" ]; then
-        docker build --build-arg BUILD_NUMBER="${BUILD_NUMBER}" -t "${REPOSITORY}/${COMPONENT_NAME}:latest-onbuild" -f "${ONBUILD_DOCKER_FILE}" "${ONBUILD_DOCKER_DIR}" || exit 1
+        docker build ${BUILD_ARGS} -t "${REPOSITORY}/${COMPONENT_NAME}:latest-onbuild" -f "${ONBUILD_DOCKER_FILE}" "${ONBUILD_DOCKER_DIR}" || exit 1
         docker tag "${REPOSITORY}/${COMPONENT_NAME}:latest-onbuild" "${REPOSITORY}/${COMPONENT_NAME}:${ASTRONOMER_VERSION}-onbuild"
     fi
 }

--- a/bin/build-images
+++ b/bin/build-images
@@ -14,8 +14,6 @@ function build_component () {
         BUILD_ARGS="${BUILD_ARGS} --build-arg VERSION=master"
     fi
 
-    echo ${BUILD_ARGS}
-
     # Build normal components
     if [ -f "${DOCKER_FILE}" ]; then
         docker build ${BUILD_ARGS} -t "${REPOSITORY}/${COMPONENT_NAME}:latest" -f "${DOCKER_FILE}" "${DOCKER_DIR}" || exit 1


### PR DESCRIPTION
This adds the ability for us to maintain a list of components to be built from their respective github `master` branches, rather than the tagged version in the actual `Dockerfile`.