### PR TITLE
Upgrades to dashboard for new kube environment

### DIFF
--- a/docker/vendor/grafana/include/airflow-containers.json
+++ b/docker/vendor/grafana/include/airflow-containers.json
@@ -27,6 +27,12 @@
       "id": "prometheus",
       "name": "Prometheus",
       "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
     }
   ],
   "annotations": {
@@ -86,7 +92,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_user_seconds_total{component_name=~\"scheduler|webserver|flower\"}[1m]) * 100",
+          "expr": "rate(container_cpu_user_seconds_total{component_name=~\".*(scheduler|webserver|flower)\"}[1m]) * 100",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{component_name}}",
@@ -166,7 +172,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_usage_bytes{component_name=~\"scheduler|webserver|flower\"}",
+          "expr": "container_memory_usage_bytes{component_name=~\".*(scheduler|webserver|flower)\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{component_name}}",
@@ -246,7 +252,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(container_network_receive_bytes_total{component_name=~\"scheduler|webserver|flower\"}[1m])",
+          "expr": "irate(container_network_receive_bytes_total{component_name=~\".*(scheduler|webserver|flower)\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{component_name}}",
@@ -326,7 +332,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(container_network_transmit_bytes_total{component_name=~\"scheduler|webserver|flower\"}[1m])",
+          "expr": "irate(container_network_transmit_bytes_total{component_name=~\".*(scheduler|webserver|flower)\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{component_name}}",
@@ -406,10 +412,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "rate(container_cpu_user_seconds_total{component_name=\"worker\"}[1m]) * 100",
+          "expr": "rate(container_cpu_user_seconds_total{component_name=~\".*(worker)\"}[1m]) * 100",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Worker  {{component_instance}}",
+          "legendFormat": "{{component_name}} {{component_instance}}",
           "refId": "A"
         }
       ],
@@ -486,10 +492,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "container_memory_usage_bytes{component_name=\"worker\"}",
+          "expr": "container_memory_usage_bytes{component_name=~\".*(worker)\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Worker {{component_instance}}",
+          "legendFormat": "{{component_name}} {{component_instance}}",
           "refId": "A"
         }
       ],
@@ -566,10 +572,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(container_network_receive_bytes_total{component_name=\"worker\"}[1m])",
+          "expr": "irate(container_network_receive_bytes_total{interface=\"eth0\", component_name=~\".*(worker)\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Worker {{component_instance}}",
+          "legendFormat": "{{component_name}} {{component_instance}}",
           "refId": "A"
         }
       ],
@@ -646,10 +652,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "irate(container_network_transmit_bytes_total{component_name=\"worker\"}[1m])",
+          "expr": "irate(container_network_transmit_bytes_total{interface=\"eth0\", component_name=~\".*(worker)\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Worker {{component_instance}}",
+          "legendFormat": "{{component_name}} {{component_instance}}",
           "refId": "A"
         }
       ],
@@ -728,5 +734,6 @@
   },
   "timezone": "",
   "title": "Airflow Containers",
+  "uid": "CNgp9IKmk",
   "version": 1
 }

--- a/docker/vendor/grafana/include/airflow-scheduler.json
+++ b/docker/vendor/grafana/include/airflow-scheduler.json
@@ -980,5 +980,6 @@
   },
   "timezone": "",
   "title": "Airflow Scheduler",
+  "uid": "DKiGzDFmk",
   "version": 1
 }


### PR DESCRIPTION
Minor changes to regex matching and label formatting. Prometheus config in kubernetes passes release name in as part of `{{component_name}}`. Tested in docker-compose and in helm charts on kubernetes.