### PR TITLE
Rearrange COPY commands

### DIFF
--- a/docker/platform/airflow/onbuild/Dockerfile
+++ b/docker/platform/airflow/onbuild/Dockerfile
@@ -20,12 +20,9 @@ ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
-# Update repositories
-ONBUILD RUN apk update
-
 # Install alpine packages
 ONBUILD COPY packages.txt .
-ONBUILD RUN cat packages.txt | xargs apk add
+ONBUILD RUN cat packages.txt | xargs apk add --no-cache
 
 # Install python packages
 ONBUILD COPY requirements.txt .

--- a/docker/platform/airflow/onbuild/Dockerfile
+++ b/docker/platform/airflow/onbuild/Dockerfile
@@ -20,7 +20,16 @@ ARG BUILD_NUMBER=-1
 LABEL io.astronomer.docker=true
 LABEL io.astronomer.docker.build.number=$BUILD_NUMBER
 
-ONBUILD COPY . .
+# Update repositories
 ONBUILD RUN apk update
+
+# Install alpine packages
+ONBUILD COPY packages.txt .
 ONBUILD RUN cat packages.txt | xargs apk add
+
+# Install python packages
+ONBUILD COPY requirements.txt .
 ONBUILD RUN pip install --no-cache-dir -q -r requirements.txt
+
+# Copy entire project directory
+ONBUILD COPY . .


### PR DESCRIPTION
This creates several layers for caching and ensures that we don't `apk add` and `pip install` every time a dag/plugin file changes.

- If `packages.txt` changes, we essentially rebuild from our airflow base.
- If `requirements.txt` changes, we only rebuild starting with `pip install`, and skip `apk add`.
- If dag/plugin/anything else changes, we skip both `apk add` and `pip install`.

Since we aren't creating new layers each time, `astro airflow deploy` (`docker push`) is also a lot faster since it determines that the previously pushed layers already exist in the remote registry. 

This should speed up development and deployment.

Initial pushes will still take a little extra time since it has to push all the layers for the first time. Wondering if we could "warm the cache" in the registry with an init container or something that pre-loads the registry with the base image and all it's layers.