### PR TITLE
Remove bcrypt dependency

### DIFF
--- a/docker/platform/houston-api/Dockerfile
+++ b/docker/platform/houston-api/Dockerfile
@@ -36,7 +36,6 @@ RUN apk add --no-cache --virtual .build-deps \
 		nodejs \
 		openssl \
 	&& npm install -g ${REPO_URL} --unsafe \
-	&& npm rebuild bcrypt --build-from-source \
 	&& apk del .build-deps
 
 EXPOSE 8870


### PR DESCRIPTION
Removes `bcrypt` rebuild as we are now relying on the `bcryptjs`